### PR TITLE
Add grupy-rp estatistics

### DIFF
--- a/eventos/grupos-python.md
+++ b/eventos/grupos-python.md
@@ -1,6 +1,15 @@
 Encontros de Python
 ================
 
+
+## São Paulo
+
+
+Grupo | Local | Número de eventos | Número de Participantes
+--- | --- | --- | ---
+Grupy-RP | Ribeirão Preto | 7 (entre dojos e palestras) | 12.5
+
+
 <!-- ## Sudeste
 
 ###Rio de Janeiro
@@ -8,7 +17,6 @@ Grupo |Local | Número de eventos | Número de Participantes
 
 --- | --- | --- 
 
-###São Paulo
 ###Minas Gerais
 ###Espírito Santo
 


### PR DESCRIPTION
Nós não temos estatísticas exatas de todos os encontros, apenas dos de Dojos no repositório [1] porque é feita uma lista com os presentes no Readme.md...

Então tirei uma estimativa do mesmo número de pessoas nos encontros de "Pylestras", que acontecem de modo intercalado.

Em cada dojo, tivemos 18, 13, 11 e 8 pessoas, foram 4 dojos e 3 "pylestras", dando uma média de 12,5 pessoas por encontro.

[1] https://github.com/grupyrp/dojos

*ps movi o subtítulo de São Paulo pra fora do comentário, não tenho certeza se era pra fazer isso, se não era, me avise que volto para onde estava.